### PR TITLE
Text glitch fix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,6 @@
 body * {
     box-sizing: border-box;
+    white-space: nowrap;
 }
 
 #bonus,


### PR DESCRIPTION
Add white-space: nowrap all the elements under body so that text won't be wrapped unnecessarily.

#18 